### PR TITLE
RDKEMW-3752:[RDKE][Xumo]"bluetoothd" process crash is observed

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_5.48.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_5.48.bbappend
@@ -54,6 +54,7 @@ SRC_URI:append = " \
     file://bluez-5.48-063-stop-gatt-db-reset-on-early-disconnection.patch \
     file://bluez-5.48-064-allow-large-sevices-changed-gatt.patch \
     file://bluz5_5.48_gatt_db_service_crash.patch \
+    file://bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch \
     "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
@@ -17,7 +17,7 @@ Index: bluez-5.48/profiles/audio/avdtp.c
  {
  	struct conf_rej rej;
  	struct avdtp_local_sep *sep;
-+	if(session == NULL){
++	if(session == NULL){;
 +	        error("session is NULL"); // Handle session if NULL
 +	        DBG("session is NUll");
 +	        return;

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
@@ -17,7 +17,7 @@ Index: bluez-5.48/profiles/audio/avdtp.c
  {
  	struct conf_rej rej;
  	struct avdtp_local_sep *sep;
-+	if(session == NULL){;
++	if(session == NULL){
 +	        error("session is NULL"); // Handle session if NULL
 +	        DBG("session is NUll");
 +	        return;

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch
@@ -1,0 +1,27 @@
+###################################################################################################
+Date: Tue, 01 July 2025
+
+Subject: Observing bluetoothd crash in setconf_cb function
+
+NULL checks added to avoid dereferrencing NULL pointers
+
+Source: Bluez open source
+Upstream-Status: Pending
+Signed-off-by:Darshan Desale Darshan_Desale@comcast.com 
+###################################################################################################
+Index: bluez-5.48/profiles/audio/avdtp.c
+===================================================================
+--- bluez-5.48.orig/profiles/audio/avdtp.c
++++ bluez-5.48/profiles/audio/avdtp.c
+@@ -1424,6 +1424,11 @@ static void setconf_cb(struct avdtp *ses
+ {
+ 	struct conf_rej rej;
+ 	struct avdtp_local_sep *sep;
++	if(session == NULL){
++	        error("session is NULL"); // Handle session if NULL
++	        DBG("session is NUll");
++	        return;
++	}
+ 
+ 	if (err != NULL) {
+ 		rej.error = AVDTP_UNSUPPORTED_CONFIGURATION;


### PR DESCRIPTION
Reason for change: Prevent bluetoothd crash in setconf_cb() when passing session as a parameter to avdtp_send function.
Priority: P1
Test Procedure: Follow the steps provided in description.
Risks: High
Signed-off-by:Darshan Desale Darshan_Desale@comcast.com