### PR TITLE
RDK-58391 : Removing Unused Binaries from RDKE

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_5.48.bb
+++ b/recipes-connectivity/bluez5/bluez5_5.48.bb
@@ -57,12 +57,10 @@ NOINST_TOOLS_BT ?= " \
     tools/advtest \
     tools/seq2bseq \
     tools/nokfw \
-    tools/create-image \
     tools/eddystone \
     tools/ibeacon \
     tools/btgatt-client \
     tools/btgatt-server \
-    tools/test-runner \
     tools/check-selftest \
     tools/gatt-service \
     profiles/iap/iapd \

--- a/recipes-connectivity/bluez5/bluez5_5.48.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_5.48.bbappend
@@ -55,6 +55,7 @@ SRC_URI:append = " \
     file://bluez-5.48-064-allow-large-sevices-changed-gatt.patch \
     file://bluz5_5.48_gatt_db_service_crash.patch \
     file://bluez-5.48-065-profiles_audio_avdtp_setconf_cb_crash_Fix.patch \
+    file://bluez-5.48-066-remove-unused-binaries.patch \
     "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-066-remove-unused-binaries.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-066-remove-unused-binaries.patch
@@ -1,0 +1,69 @@
+###################################################################################################
+Date: wed, 09 July 2025
+
+Subject: Remove unused/unmapped bluetooth binaries
+
+Source: Bluez open source
+Upstream-Status: Pending
+Signed-off-by: Tharun Kumar Venkatachalem <tharunkumar_venkatachalem@comcast.com>
+###################################################################################################
+Index: bluez-5.48/Makefile.tools
+===================================================================
+--- bluez-5.48.orig/Makefile.tools
++++ bluez-5.48/Makefile.tools
+@@ -174,7 +174,7 @@ tools_userchan_tester_LDADD = lib/libblu
+ endif
+ 
+ if TOOLS
+-bin_PROGRAMS += tools/rctest tools/l2test tools/l2ping tools/bccmd \
++bin_PROGRAMS += tools/l2test tools/l2ping tools/bccmd \
+ 			tools/bluemoon tools/hex2hcd tools/mpris-proxy \
+ 			tools/btattach tools/bdaddr
+ 
+@@ -185,10 +185,10 @@ noinst_PROGRAMS += tools/avinfo tools/av
+ 			tools/btsnoop tools/btproxy \
+ 			tools/btiotest tools/bneptest tools/mcaptest \
+ 			tools/cltest tools/oobtest tools/advtest \
+-			tools/seq2bseq tools/nokfw tools/create-image \
++			tools/seq2bseq tools/nokfw \
+ 			tools/eddystone tools/ibeacon \
+ 			tools/btgatt-client tools/btgatt-server \
+-			tools/test-runner tools/check-selftest \
++			tools/check-selftest \
+ 			tools/gatt-service profiles/iap/iapd
+ 
+ tools_bdaddr_SOURCES = tools/bdaddr.c src/oui.h src/oui.c
+@@ -249,7 +249,6 @@ tools_seq2bseq_SOURCES = tools/seq2bseq.
+ 
+ tools_nokfw_SOURCES = tools/nokfw.c
+ 
+-tools_create_image_SOURCES = tools/create-image.c
+ 
+ tools_eddystone_SOURCES = tools/eddystone.c monitor/bt.h
+ tools_eddystone_LDADD = src/libshared-mainloop.la
+@@ -265,7 +264,6 @@ tools_btgatt_server_SOURCES = tools/btga
+ tools_btgatt_server_LDADD = src/libshared-mainloop.la \
+ 						lib/libbluetooth-internal.la
+ 
+-tools_rctest_LDADD = lib/libbluetooth-internal.la
+ 
+ tools_l2test_LDADD = lib/libbluetooth-internal.la
+ 
+@@ -291,7 +289,7 @@ tools_gatt_service_LDADD = @GLIB_LIBS@ @
+ profiles_iap_iapd_SOURCES = profiles/iap/main.c
+ profiles_iap_iapd_LDADD = gdbus/libgdbus-internal.la @GLIB_LIBS@ @DBUS_LIBS@
+ 
+-dist_man_MANS += tools/rctest.1 tools/l2ping.1 tools/bccmd.1 tools/btattach.1
++dist_man_MANS += tools/l2ping.1 tools/bccmd.1 tools/btattach.1
+ 
+ EXTRA_DIST += tools/bdaddr.1
+ 
+@@ -359,7 +357,7 @@ EXTRA_DIST += tools/hciattach.1 tools/hc
+ 			tools/rfcomm.1 tools/sdptool.1 tools/ciptool.1
+ endif
+ else
+-EXTRA_DIST += tools/rctest.1 tools/l2ping.1 tools/bccmd.1 tools/btattach.1
++EXTRA_DIST += tools/l2ping.1 tools/bccmd.1 tools/btattach.1
+ endif
+ 
+ if HID2HCI


### PR DESCRIPTION
Reason for change: Removed unused/unmapped bluetooth binaries
Test Procedure: Check the status of bluetooth service
Risks: Low