### PR TITLE
RDKTV-36805: bluetoothd crash fix

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_5.48.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_5.48.bbappend
@@ -54,6 +54,7 @@ SRC_URI:append = " \
     file://bluez-5.48-063-stop-gatt-db-reset-on-early-disconnection.patch \
     file://bluez-5.48-064-allow-large-sevices-changed-gatt.patch \
     file://bluz5_5.48_gatt_db_service_crash.patch \
+    file://bluez-5.48-065-unregister-batt_io_ccc_written_cb-check-session.patch \
     "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-unregister-batt_io_ccc_written_cb-check-session.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-065-unregister-batt_io_ccc_written_cb-check-session.patch
@@ -1,0 +1,40 @@
+Index: bluez-5.48/profiles/battery/battery.c
+===================================================================
+--- bluez-5.48.orig/profiles/battery/battery.c
++++ bluez-5.48/profiles/battery/battery.c
+@@ -248,6 +248,7 @@ static void batt_remove(struct btd_servi
+ 	struct btd_device *device = btd_service_get_device(service);
+ 	struct batt *batt;
+ 	char addr[18];
++	struct bt_gatt_client *client = btd_device_get_gatt_client(device);
+ 
+ 	ba2str(device_get_address(device), addr);
+ 	DBG("BATT profile remove (%s)", addr);
+@@ -258,6 +259,8 @@ static void batt_remove(struct btd_servi
+ 		return;
+ 	}
+ 
++	DBG("notify_id: %d", batt->batt_level_cb_id);
++	bt_gatt_client_unregister_notify(client, batt->batt_level_cb_id);
+ 	batt_free(batt);
+ }
+ 
+Index: bluez-5.48/profiles/audio/avdtp.c
+===================================================================
+--- bluez-5.48.orig/profiles/audio/avdtp.c
++++ bluez-5.48/profiles/audio/avdtp.c
+@@ -1425,6 +1425,13 @@ static void setconf_cb(struct avdtp *ses
+ 	struct conf_rej rej;
+ 	struct avdtp_local_sep *sep;
+ 
++	if (!session) {
++		error("session is NULL");
++		if(stream)
++			stream_free(stream);
++		return;
++	}
++
+ 	if (err != NULL) {
+ 		rej.error = AVDTP_UNSUPPORTED_CONFIGURATION;
+ 		rej.category = err->err.error_code;
+


### PR DESCRIPTION
Reason for change: Fix for 2 crashes
Test Procedure: connect remote via BLE and wait
Risks: Low
Priority: P1