### PR TITLE
RDKBACCL-1077 : Scarthgap - virtual/kernel build for kernel-6.6 filogic SDK

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_oss-common-config = "^${LAYERDIR}/"
 BBFILE_PRIORITY_oss-common-config = "6"
 
 LAYERDEPENDS_oss-common-config = "core"
-LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone"
+LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone scarthgap"
 
 require include/override-pkgrev.inc
 


### PR DESCRIPTION
Reason for change : fixing scarthgap build issues for linux-mediatek
Test Procedure : bitbake linux-mediatek
Risks: None