### PR TITLE
RDKBACCL-1034: Recreated bluez5 patch in OSS-common-config  layer

### DIFF
--- a/recipes-connectivity/bluez5/bluez5/0001-bluetooth_service_in_generic.patch
+++ b/recipes-connectivity/bluez5/bluez5/0001-bluetooth_service_in_generic.patch
@@ -4,6 +4,7 @@ Subject: [PATCH] DELIA-24590 RDK-27733: Removing do_postpatch from Bluetooth Rec
         add patch file for modifying bluetooth.service.
 Source: COMCAST
 Signed-off-by: mselva006c <mani_selvaraj@comcast.com>
+Upstream-Status: Pending
 ---
  src/bluetooth.service.in | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/recipes-connectivity/bluez5/bluez5/0001-bluetooth_service_in_generic.patch
+++ b/recipes-connectivity/bluez5/bluez5/0001-bluetooth_service_in_generic.patch
@@ -8,10 +8,10 @@ Signed-off-by: mselva006c <mani_selvaraj@comcast.com>
  src/bluetooth.service.in | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/src/bluetooth.service.in b/src/bluetooth.service.in
-index f9faaa4..18e5687 100644
---- a/src/bluetooth.service.in
-+++ b/src/bluetooth.service.in
+Index: bluez-5.72/src/bluetooth.service.in
+===================================================================
+--- bluez-5.72.orig/src/bluetooth.service.in
++++ bluez-5.72/src/bluetooth.service.in
 @@ -1,5 +1,7 @@
  [Unit]
  Description=Bluetooth service
@@ -28,4 +28,4 @@ index f9faaa4..18e5687 100644
 +Restart=always
  CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
  LimitNPROC=1
- ProtectHome=true
+ 

--- a/recipes-connectivity/bluez5/bluez5_5.%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_5.%.bbappend
@@ -31,8 +31,8 @@ RREPLACES:${PN} += "${PN}-systemd"
 RCONFLICTS:${PN} += "${PN}-systemd"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-#SRC_URI += "file://0001-bluetooth_service_in_generic.patch \
-#           "
+SRC_URI += "file://0001-bluetooth_service_in_generic.patch \
+           "
 
 do_install:append() {
     mkdir -p ${D}${includedir}/bluetooth/audio/


### PR DESCRIPTION
Recreated  0001-bluetooth_service_in_generic.patch patch for bluez5_5.72 version in scarthgap. 