### PR TITLE
RDKOSS-553: use after free stream crash

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_5.48.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_5.48.bbappend
@@ -56,6 +56,7 @@ SRC_URI:append = " \
     file://bluz5_5.48_gatt_db_service_crash.patch \
     file://bluez-5.48-065-unregister-batt_io_ccc_written_cb-check-session.patch \
     file://bluez-5.48-066-remove-unused-binaries.patch \
+    file://bluez-5.48-067-RDKOSS-553-stream-use-after-free.patch \
     "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-067-RDKOSS-553-stream-use-after-free.patch
+++ b/recipes-connectivity/bluez5/bluez5_5.48/bluez-5.48-067-RDKOSS-553-stream-use-after-free.patch
@@ -1,0 +1,39 @@
+Index: bluez-5.48/profiles/audio/avdtp.c
+===================================================================
+--- bluez-5.48.orig/profiles/audio/avdtp.c
++++ bluez-5.48/profiles/audio/avdtp.c
+@@ -707,6 +707,11 @@ static void stream_free(void *data)
+ 	struct avdtp_stream *stream = data;
+ 	struct avdtp_remote_sep *rsep;
+ 
++        if(!stream) {
++            error("stream is NULL");
++            return;
++        }
++
+ 	if (stream->lsep) {
+             stream->lsep->info.inuse = 0;
+             if (stream->lsep->stream)
+@@ -1020,8 +1025,11 @@ static void avdtp_sep_set_state(struct a
+ 		cb->cb(stream, old_state, state, err_ptr, cb->user_data);
+ 	}
+ 
+-	if (state == AVDTP_STATE_IDLE)
+-		stream_free(stream);
++	if (state == AVDTP_STATE_IDLE) {
++                DBG("stream_free is called");
++                stream_free(stream);
++                sep->stream = NULL;
++        }
+ }
+ 
+ static void finalize_discovery(struct avdtp *session, int err)
+@@ -1441,8 +1449,6 @@ static void setconf_cb(struct avdtp *ses
+ 
+ 	if (!session) {
+ 		error("session is NULL");
+-		if(stream)
+-			stream_free(stream);
+ 		return;
+ 	}
+ 


### PR DESCRIPTION
Reason for change: Use after free fix
Test Procedure: Connect to bluetooth devices
Risks: Low
Priority: P1