### PR TITLE
RDKBACCL-1828: Make 6.12 kernel build changes in wrynose build

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_oss-common-config = "^${LAYERDIR}/"
 BBFILE_PRIORITY_oss-common-config = "6"
 
 LAYERDEPENDS_oss-common-config = "core"
-LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone"
+LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone wrynose"
 
 require include/override-pkgrev.inc
 


### PR DESCRIPTION
Reason for change : Added wrynose compat support to this layer
Test procedure: None
Risk: None