### PR TITLE
RDKBACCL-1837 : Build core-image-minimal for wrynose

### DIFF
--- a/conf/include/override-pkgrev.inc
+++ b/conf/include/override-pkgrev.inc
@@ -1,4 +1,4 @@
 
 # Use jquery version from poky
-PV:pn-jquery = "3.6.0"
+PV:pn-jquery = "3.7.1"
 PR:pn-jquery = "r0"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_oss-common-config = "^${LAYERDIR}/"
 BBFILE_PRIORITY_oss-common-config = "6"
 
 LAYERDEPENDS_oss-common-config = "core"
-LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone"
+LAYERSERIES_COMPAT_oss-common-config = "dunfell kirkstone wrynose"
 
 require include/override-pkgrev.inc
 


### PR DESCRIPTION
RDKBACCL-1837: Build core-image-minimal for wrynose 
Reason for change: Initial changes for wrynose build in BPI
Test Procedure: Check Wrynose build
Risks: Low
Priority: P1

Signed-off-by: ssaman560 <sipra_samantaray2@comcast.com>